### PR TITLE
Modifications docstrings de certains Contrats

### DIFF
--- a/capytale/contracts/src/mode.ts
+++ b/capytale/contracts/src/mode.ts
@@ -1,5 +1,15 @@
 /**
  * Ce module définit la transmission du mode de l'activité.
+ *
+ * Les modes peuvent être :
+ *    - `"create"` - Pour un enseignant en train de créer/modifier une activité.
+ *    - `"assignment"` - Pour un élève/participant en train d'effectuer le travail demandé.
+ *    - `"review"` - Pour un enseignant regardant la copie d'un élève.participant (que la
+ *                   copie soit finalisée ou non: voir le contrat `workflow`).
+ *    - `"view"` - Pour un enseignant regardant une activité créée par un autre enseignant
+ *                 depuis la bibliothèque d'activité de Capytale.
+ *
+ * Souscription avec `mode:{v}`, où `{v}` est le numéro de version du contrat.
  */
 
 type Mode =
@@ -32,11 +42,10 @@ export type ModeV1 = {
      */
     application: {
         /**
-         * Le *MetaPlayer* appelle cette méthode pour indiquer le mode à l'*Application*,
-         * après avoir appelé la méthode `loadContent`.
-         * Ne devrait être appelé qu'une seule fois.
+         * Le *MetaPlayer* appelle systématiquement cette méthode pour indiquer le mode à l'*Application*
+         * avant d'avoir appelé la méthode `loadContent` des contrats `simple-content`.
          * 
-         * @param mode le mode à appliquer. 
+         * @param mode le mode utilisé actuellement pour l'activité. 
         */
         setMode(mode: Mode): void;
     };

--- a/capytale/contracts/src/mode.ts
+++ b/capytale/contracts/src/mode.ts
@@ -38,7 +38,7 @@ export type ModeV1 = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
-     * Les méthodes non implantées sont ignorées.
+     * Toutes les méthodes sont asynchrones.
      */
     application: {
         /**

--- a/capytale/contracts/src/mode.ts
+++ b/capytale/contracts/src/mode.ts
@@ -28,10 +28,12 @@ export type ModeV1 = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
+     * Les méthodes non implantées sont ignorées.
      */
     application: {
         /**
-         * Le *MetaPlayer* appelle cette méthode pour indiquer le mode à l'*Application*.
+         * Le *MetaPlayer* appelle cette méthode pour indiquer le mode à l'*Application*,
+         * après avoir appelé la méthode `loadContent`.
          * Ne devrait être appelé qu'une seule fois.
          * 
          * @param mode le mode à appliquer. 

--- a/capytale/contracts/src/reload.ts
+++ b/capytale/contracts/src/reload.ts
@@ -1,5 +1,14 @@
 /**
- * Ce module définit le mécanisme de rechargement de l'iFrame.
+ * Ce module définit le mécanisme de rechargement de l'iFrame:
+ * 
+ * Si l'*Application* n'est pas une SWA (Single Web App), il peut lui être nécessaire de changer de page
+ * en cours d'utilisation. Dans ce cas, le *MetaPlayer* doit être notifié pour que l'iFrame soit détruite 
+ * et reconstruite avec la nouvelle URL.
+ * Ce contrat permet également de transmettre les informations sur le contenu actuel de l'*Application*
+ * entre la page initiale et la nouvelle page, sans passer par le mécanisme de sauvegarde des contrats
+ * de type `simple-content`.
+ *
+ * Souscription au contrat avec `reload:{v}`, où `{v}` est le numéro de version.
  */
 
 /**
@@ -18,18 +27,19 @@ export type ReloadV1 = {
          * 
          * - L'iFrame est détruite puis recréée avec la nouvelle adresse.
          * - Le *MetaPlayer* récupère un état (`state`) contenant toutes les données qui devront
-         *   être données ensuite à la nouvelle instance de l'*Application* (à minima, toutes les 
+         *   être ensuite passées à la nouvelle instance de l'*Application* (à minima, toutes les 
          *   données liée à l'activité en cours).
-         * - Après rechargement, le *MetaPlayer* n'appellera _PAS_ la méthode `loadContent`
-         *   du contrat de l'*Application*, mais la méthode `reloaded` du présent contrat.
+         * - Après chargement de la nouvelle page, l'*Application* souscrit aux différents contrats,
+         * mais le *MetaPlayer* n'appellera _PAS_ la méthode `loadContent` : c'est la la méthode 
+         * `reloaded` du présent contrat qui sera appelée à la place.
          * 
          * @param url l'URL à charger dans l'iFrame.
-         *            Si null, l'URL actuelle est rechargée.
-         *            ATTENTION: si la logique de l'*Application* repose sur des paramètres passés 
-         *            via l'URL, ne pas oublier de les rajouter.
+         *        Si `null`, l'URL actuelle est rechargée.
+         *        ATTENTION: si la logique de l'*Application* repose sur des paramètres passés 
+         *        via l'URL, ne pas oublier de les rajouter à cet argument.
          * 
          * @param state un état à transmettre à l'application après le rechargement.
-         *        L'objet state doit être serializable avec JSON.stringify.
+         *        L'objet `state` doit être serializable avec JSON.stringify.
          * 
          */
         reload(url?: string | null, state?: any): void;
@@ -37,12 +47,11 @@ export type ReloadV1 = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
-     * Les méthodes non implantées sont ignorées.
      */
     application: {
         /**
          * Le *MetaPlayer* appelle cette méthode pour indiquer à l'*Application* qu'un
-         * rechargement a eu lieu.
+         * rechargement a eu lieu et lui passé le dernier état de l'*Ap^plication*.
          * Cette méthode est appelée en lieu et place de `loadContent`, suite à une
          * demande de rechargement.
          * 

--- a/capytale/contracts/src/reload.ts
+++ b/capytale/contracts/src/reload.ts
@@ -20,7 +20,7 @@ export type ReloadV1 = {
          * - Le *MetaPlayer* récupère un état (`state`) contenant toutes les données qui devront
          *   être données ensuite à la nouvelle instance de l'*Application* (à minima, toutes les 
          *   données liée à l'activité en cours).
-         * - Après rechargement, le *MetaPlayer* n'appellera _PAS_ la méthode `loadContent` de 
+         * - Après rechargement, le *MetaPlayer* n'appellera _PAS_ la méthode `loadContent`
          *   du contrat de l'*Application*, mais la méthode `reloaded` du présent contrat.
          * 
          * @param url l'URL à charger dans l'iFrame.

--- a/capytale/contracts/src/reload.ts
+++ b/capytale/contracts/src/reload.ts
@@ -25,6 +25,8 @@ export type ReloadV1 = {
          * 
          * @param url l'URL à charger dans l'iFrame.
          *            Si null, l'URL actuelle est rechargée.
+         *            ATTENTION: si la logique de l'*Application* repose sur des paramètres passés 
+         *            via l'URL, ne pas oublier de les rajouter.
          * 
          * @param state un état à transmettre à l'application après le rechargement.
          *        L'objet state doit être serializable avec JSON.stringify.

--- a/capytale/contracts/src/reload.ts
+++ b/capytale/contracts/src/reload.ts
@@ -13,13 +13,20 @@ export type ReloadV1 = {
      */
     metaplayer: {
         /**
-         * L'*Application* peut appeler cette méthode pour demander un rechargement.
-         * L'iFrame est détruite puis recréée.
+         * L'*Application* peut appeler cette méthode pour demander un rechargement avec l'url
+         * passée en argument.
+         * 
+         * - L'iFrame est détruite puis recréée avec la nouvelle adresse.
+         * - Le *MetaPlayer* récupère un état (`state`) contenant toutes les données qui devront
+         *   être données ensuite à la nouvelle instance de l'*Application* (à minima, toutes les 
+         *   données liée à l'activité en cours).
+         * - Après rechargement, le *MetaPlayer* n'appellera _PAS_ la méthode `loadContent` de 
+         *   du contrat de l'*Application*, mais la méthode `reloaded` du présent contrat.
          * 
          * @param url l'URL à charger dans l'iFrame.
          *            Si null, l'URL actuelle est rechargée.
          * 
-         * @param state un état éventuel à transmettre à l'application après le rechargement.
+         * @param state un état à transmettre à l'application après le rechargement.
          * 
          */
         reload(url?: string | null, state?: any): void;
@@ -27,11 +34,14 @@ export type ReloadV1 = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
+     * Les méthodes non implantées sont ignorées.
      */
     application: {
         /**
          * Le *MetaPlayer* appelle cette méthode pour indiquer à l'*Application* qu'un
          * rechargement a eu lieu.
+         * Cette méthode est appelée en lieu et place de `loadContent`, suite à une
+         * demande de rechargement.
          * 
          * @param state l'état que l'application a transmis lors de l'appel à `reload`.
          */

--- a/capytale/contracts/src/reload.ts
+++ b/capytale/contracts/src/reload.ts
@@ -27,6 +27,7 @@ export type ReloadV1 = {
          *            Si null, l'URL actuelle est rechargée.
          * 
          * @param state un état à transmettre à l'application après le rechargement.
+         *        L'objet state doit être serializable avec JSON.stringify.
          * 
          */
         reload(url?: string | null, state?: any): void;

--- a/capytale/contracts/src/reload.ts
+++ b/capytale/contracts/src/reload.ts
@@ -47,6 +47,7 @@ export type ReloadV1 = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
+     * Toutes les méthodes sont asynchrones.
      */
     application: {
         /**

--- a/capytale/contracts/src/simple-content-eval.ts
+++ b/capytale/contracts/src/simple-content-eval.ts
@@ -35,7 +35,9 @@ export type SimpleContentEvalV1<T> = {
      */
     metaplayer: {
         /**
-         * L'*Application* doit appeler cette méthode pour indiquer au *MetaPlayer* que le contenu a été modifié par l'utilisateur.
+         * L'*Application* doit appeler cette méthode pour indiquer au *MetaPlayer* que le contenu 
+         * a été modifié par l'utilisateur (permettant par exemple d'activer le bouton de sauvegarde 
+         * dans le bandeau supérieur de Capytale).
          */
         contentChanged(): void;
     };
@@ -46,8 +48,8 @@ export type SimpleContentEvalV1<T> = {
      */
     application: {
         /**
-         * Le *MetaPlayer* appelle cette méthode pour envoyer les données à l'*Application*, lors 
-         * du chargement de la page, pour transmettre les données concernant l'activité.
+         * Le *MetaPlayer* appelle cette méthode après la souscription au contrat, pour transmettre
+         * les données de l'activité à l'*Application*.
          * 
          * Si `content` est `null`, l'*Application* doit réinitialiser son contenu à la valeur par 
          * défaut initiale.
@@ -59,8 +61,7 @@ export type SimpleContentEvalV1<T> = {
 
         /**
          * Le *MetaPlayer* appelle cette méthode pour récupérer les données de l'*Application*, 
-         * lorsque l'utilisateur effectue une action demandant d'enrgistrer des données sur 
-         * Capyale (typiquement, cliquer sur le bouton Enregsitrer dans le bandeau supérieur).
+         * dans le mode create.
          * 
          * L'*Application* peut retourner `null` si le contenu correspond à la valeur par défaut
          * initiale.

--- a/capytale/contracts/src/simple-content-eval.ts
+++ b/capytale/contracts/src/simple-content-eval.ts
@@ -42,12 +42,15 @@ export type SimpleContentEvalV1<T> = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
+     * Les méthodes non implantées sont ignorées.
      */
     application: {
         /**
-         * Le *MetaPlayer* appelle cette méthode pour envoyer les données à l'*Application*.
+         * Le *MetaPlayer* appelle cette méthode pour envoyer les données à l'*Application*, lors 
+         * du chargement de la page, pour transmettre les données concernant l'activité.
          * 
-         * Si `content` est `null`, l'*Application* doit réinitialiser son contenu à la valeur par défaut initiale.
+         * Si `content` est `null`, l'*Application* doit réinitialiser son contenu à la valeur par 
+         * défaut initiale.
          * Si l'*Application* n'est pas en mesure de charger le contenu, elle doit lever une exeption.
          * 
          * @param content le contenu de l'activité
@@ -55,9 +58,17 @@ export type SimpleContentEvalV1<T> = {
         loadContent(content: T | null): void;
 
         /**
-         * Le *MetaPlayer* appelle cette méthode pour récupérer les données de l'*Application* dans le mode create.
+         * Le *MetaPlayer* appelle cette méthode pour récupérer les données de l'*Application*, 
+         * lorsque l'utilisateur effectue une action demandant d'enrgistrer des données sur 
+         * Capyale (typiquement, cliquer sur le bouton Enregsitrer dans le bandeau supérieur).
          * 
-         * L'*Application* peut retourner `null` si le contenu correspond à la valeur par défaut initiale.
+         * L'*Application* peut retourner `null` si le contenu correspond à la valeur par défaut
+         * initiale.
+         * 
+         * Contrat :
+         * Lorsque cette méthode est appelée, l'*Application* doit empêcher l'utilisateur de 
+         * modifier le contenu de la page, jusqu'à ce qu'elle reçoive la notification de fin 
+         * de sauvegarde, via l'appel à `contentSaved()`.
          * 
          * @returns le contenu de l'activité
          */

--- a/capytale/contracts/src/simple-content-eval.ts
+++ b/capytale/contracts/src/simple-content-eval.ts
@@ -11,6 +11,11 @@ type StringEvaluation = {
     score: string;
 }
 
+
+/**Représente l'évaluation d'un exercice de l'activité.
+ *   - `evalLabel`: utiliser `"Exercice N" (sert d'identifiant pour enregistrer les données)
+ *   - `evalTitle`: titre (optionnel) de l'exercice.
+ */
 type Evaluation = {
     evalLabel: string;
     evalTitle?: string;

--- a/capytale/contracts/src/simple-content-eval.ts
+++ b/capytale/contracts/src/simple-content-eval.ts
@@ -66,10 +66,6 @@ export type SimpleContentEvalV1<T> = {
          * L'*Application* peut retourner `null` si le contenu correspond à la valeur par défaut
          * initiale.
          * 
-         * Contrat :
-         * Lorsque cette méthode est appelée, l'*Application* doit empêcher l'utilisateur de 
-         * modifier le contenu de la page, jusqu'à ce qu'elle reçoive la notification de fin 
-         * de sauvegarde, via l'appel à `contentSaved()`.
          * 
          * @returns le contenu de l'activité
          */

--- a/capytale/contracts/src/simple-content-eval.ts
+++ b/capytale/contracts/src/simple-content-eval.ts
@@ -44,7 +44,7 @@ export type SimpleContentEvalV1<T> = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
-     * Les méthodes non implantées sont ignorées.
+     * Toutes les méthodes sont asynchrones.
      */
     application: {
         /**

--- a/capytale/contracts/src/simple-content.ts
+++ b/capytale/contracts/src/simple-content.ts
@@ -19,7 +19,8 @@ export type SimpleContentV1<T> = {
     metaplayer: {
         /**
          * L'*Application* doit appeler cette méthode pour indiquer au *MetaPlayer* que le contenu 
-         * a été modifié par l'utilisateur.
+         * a été modifié par l'utilisateur (permettant par exemple d'activer le bouton de sauvegarde 
+         * dans le bandeau supérieur de Capytale).
          */
         contentChanged(): void;
     };
@@ -30,8 +31,8 @@ export type SimpleContentV1<T> = {
      */
     application: {
         /**
-         * Le *MetaPlayer* appelle cette méthode pour envoyer les données à l'*Application*, lors 
-         * du chargement de la page, pour transmettre les données concernant l'activité.
+         * Le *MetaPlayer* appelle cette méthode après la souscription au contrat, pour transmettre
+         * les données de l'activité à l'*Application*.
          * 
          * Si `content` est `null`, l'*Application* doit réinitialiser son contenu à la valeur par 
          * défaut initiale.
@@ -43,7 +44,7 @@ export type SimpleContentV1<T> = {
 
         /**
          * Le *MetaPlayer* appelle cette méthode pour récupérer les données de l'*Application*, 
-         * lorsque l'utilisateur effectue une action demandant d'enrgistrer des données sur 
+         * lorsque l'utilisateur effectue une action demandant d'enregistrer des données sur 
          * Capyale (typiquement, cliquer sur le bouton Enregsitrer dans le bandeau supérieur).
          * 
          * L'*Application* peut retourner `null` si le contenu correspond à la valeur par défaut

--- a/capytale/contracts/src/simple-content.ts
+++ b/capytale/contracts/src/simple-content.ts
@@ -1,10 +1,21 @@
 /**
- * Ce module définit le contrat d'échange des contenus.
+ * Ce module définit le contrat d'échange des contenus de l'activité.
+ *
+ *    - Les données peuvent être `null` lorsqu'aucune donnée n'existe pour l'activité, 
+ *      côté Capytale (typiquement: au moment de la création de l'activité).
+ *    - Les données pour une acivité doivent toujours être du même type, quel que soit 
+ *      le mode utilisé (create, assignment, ...).
+ *
+ * Souscription avec `"simple-content({type}):{v}"`, où :
+ *    - `{v}` est le numéro de version du contrat.
+ *    - `{type}` est le type de données utilisées par l'*Application*. Peut être:
+ *            json
+ *            text
  */
 
 /**
  * Un contrat pour gérer un contenu simple :
- * - un seul contenu de type `T`
+ * - un seul contenu de type `T|null`
  * - le mode assignment est le même que le mode create c'est à dire que
  *   le contenu initial pour l'élève est celui qui a été préparé par l'enseignant.
  * 
@@ -27,16 +38,16 @@ export type SimpleContentV1<T> = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
-     * Les méthodes non implantées sont ignorées.
      */
     application: {
         /**
          * Le *MetaPlayer* appelle cette méthode après la souscription au contrat, pour transmettre
          * les données de l'activité à l'*Application*.
          * 
-         * Si `content` est `null`, l'*Application* doit réinitialiser son contenu à la valeur par 
-         * défaut initiale.
-         * Si l'*Application* n'est pas en mesure de charger le contenu, elle doit lever une exeption.
+         *     - Si `content` est `null`, l'*Application* doit initialiser son contenu à la valeur 
+         *       par défaut initiale.
+         *     - Si l'*Application* n'est pas en mesure de charger le contenu, elle doit lever une 
+         *       exeption.
          * 
          * @param content le contenu de l'activité
         */
@@ -47,9 +58,8 @@ export type SimpleContentV1<T> = {
          * lorsque l'utilisateur effectue une action demandant d'enregistrer des données sur 
          * Capyale (typiquement, cliquer sur le bouton Enregsitrer dans le bandeau supérieur).
          * 
-         * L'*Application* peut retourner `null` si le contenu correspond à la valeur par défaut
+         * L'*Application* peut renvoyer `null` si le contenu correspond à la valeur par défaut
          * initiale.
-         * 
          * 
          * @returns le contenu de l'activité
          */
@@ -57,7 +67,13 @@ export type SimpleContentV1<T> = {
 
         /**
          * Le *MetaPlayer* appelle cette méthode pour indiquer à l'*Application* que le contenu 
-         * a été sauvegardé.
+         * a été sauvegardé, côté Capytale.
+         *
+         * Cette notification peut être utile à l'*Application* si elle gère des états `dirty` 
+         * (données non enregistrées dans Capytale) pour éviter que l'utilisateur ne puisse faire 
+         * certaines actions qui lui ferait perdre ces données par mégarde.
+         *
+         * Cette méthode n'est appelée que si la sauvegarde a été un succès.
          */
         contentSaved(): void;
     };

--- a/capytale/contracts/src/simple-content.ts
+++ b/capytale/contracts/src/simple-content.ts
@@ -50,10 +50,6 @@ export type SimpleContentV1<T> = {
          * L'*Application* peut retourner `null` si le contenu correspond à la valeur par défaut
          * initiale.
          * 
-         * Contrat :
-         * Lorsque cette méthode est appelée, l'*Application* doit empêcher l'utilisateur de 
-         * modifier le contenu de la page, jusqu'à ce qu'elle reçoive la notification de fin 
-         * de sauvegarde, via l'appel à `contentSaved()`.
          * 
          * @returns le contenu de l'activité
          */

--- a/capytale/contracts/src/simple-content.ts
+++ b/capytale/contracts/src/simple-content.ts
@@ -18,19 +18,23 @@ export type SimpleContentV1<T> = {
      */
     metaplayer: {
         /**
-         * L'*Application* doit appeler cette méthode pour indiquer au *MetaPlayer* que le contenu a été modifié par l'utilisateur.
+         * L'*Application* doit appeler cette méthode pour indiquer au *MetaPlayer* que le contenu 
+         * a été modifié par l'utilisateur.
          */
         contentChanged(): void;
     };
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
+     * Les méthodes non implantées sont ignorées.
      */
     application: {
         /**
-         * Le *MetaPlayer* appelle cette méthode pour envoyer les données à l'*Application*.
+         * Le *MetaPlayer* appelle cette méthode pour envoyer les données à l'*Application*, lors 
+         * du chargement de la page, pour transmettre les données concernant l'activité.
          * 
-         * Si `content` est `null`, l'*Application* doit réinitialiser son contenu à la valeur par défaut initiale.
+         * Si `content` est `null`, l'*Application* doit réinitialiser son contenu à la valeur par 
+         * défaut initiale.
          * Si l'*Application* n'est pas en mesure de charger le contenu, elle doit lever une exeption.
          * 
          * @param content le contenu de l'activité
@@ -38,16 +42,25 @@ export type SimpleContentV1<T> = {
         loadContent(content: T | null): void;
 
         /**
-         * Le *MetaPlayer* appelle cette méthode pour récupérer les données de l'*Application*.
+         * Le *MetaPlayer* appelle cette méthode pour récupérer les données de l'*Application*, 
+         * lorsque l'utilisateur effectue une action demandant d'enrgistrer des données sur 
+         * Capyale (typiquement, cliquer sur le bouton Enregsitrer dans le bandeau supérieur).
          * 
-         * L'*Application* peut retourner `null` si le contenu correspond à la valeur par défaut initiale.
+         * L'*Application* peut retourner `null` si le contenu correspond à la valeur par défaut
+         * initiale.
+         * 
+         * Contrat :
+         * Lorsque cette méthode est appelée, l'*Application* doit empêcher l'utilisateur de 
+         * modifier le contenu de la page, jusqu'à ce qu'elle reçoive la notification de fin 
+         * de sauvegarde, via l'appel à `contentSaved()`.
          * 
          * @returns le contenu de l'activité
          */
         getContent(): T | null;
 
         /**
-         * Le *MetaPlayer* appelle cette méthode pour indiquer à l'*Application* que le contenu a été sauvegardé.
+         * Le *MetaPlayer* appelle cette méthode pour indiquer à l'*Application* que le contenu 
+         * a été sauvegardé.
          */
         contentSaved(): void;
     };

--- a/capytale/contracts/src/simple-content.ts
+++ b/capytale/contracts/src/simple-content.ts
@@ -38,6 +38,7 @@ export type SimpleContentV1<T> = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
+     * Toutes les méthodes sont asynchrones.
      */
     application: {
         /**

--- a/capytale/contracts/src/theme.ts
+++ b/capytale/contracts/src/theme.ts
@@ -23,6 +23,7 @@ export type ThemeV1 = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
+     * Toutes les méthodes sont asynchrones.
      */
     application: {
         /**

--- a/capytale/contracts/src/theme.ts
+++ b/capytale/contracts/src/theme.ts
@@ -23,7 +23,6 @@ export type ThemeV1 = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
-     * Les méthodes non implantées sont ignorées.
      */
     application: {
         /**

--- a/capytale/contracts/src/theme.ts
+++ b/capytale/contracts/src/theme.ts
@@ -1,5 +1,5 @@
 /**
- * Ce module définit la transmission du thème d'affichage.
+ * Ce module définit la transmission du thème d'affichage (`"dark"|"light"`).
  */
 
 /**

--- a/capytale/contracts/src/theme.ts
+++ b/capytale/contracts/src/theme.ts
@@ -23,6 +23,7 @@ export type ThemeV1 = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
+     * Les méthodes non implantées sont ignorées.
      */
     application: {
         /**

--- a/capytale/contracts/src/workflow.ts
+++ b/capytale/contracts/src/workflow.ts
@@ -9,7 +9,7 @@
  *                     dans les paramètres de l'activité).
  *    - `"corrected"` - L'enseignant a marqué la copie comme corrigée/évaluée.
  * 
- * Souscription avec `workdlow:{v}`, où `{v}` est le numéro de version du contrat.
+ * Souscription avec `workflow:{v}`, où `{v}` est le numéro de version du contrat.
  */
 
 type Workflow = 'current' | 'finished' | 'corrected';

--- a/capytale/contracts/src/workflow.ts
+++ b/capytale/contracts/src/workflow.ts
@@ -24,6 +24,7 @@ export type WorkflowV1 = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
+     * Les méthodes non implantées sont ignorées.
      */
     application: {
         /**

--- a/capytale/contracts/src/workflow.ts
+++ b/capytale/contracts/src/workflow.ts
@@ -1,7 +1,7 @@
 /**
  * Ce module définit la transmission de l'état actuel du workflow de la copie d'un 
  * élève/participant.
- * L'état workflow peut prendre l'une des valeurs suivante :
+ * L'état workflow peut prendre l'une des valeurs suivantes :
  * 
  *    - `"current"`  - L'élève n'a pas encore rendu la copie.
  *    - `"finished"` - L'élève a rendu la copie : il ne peut plus la modifier (il peut encore

--- a/capytale/contracts/src/workflow.ts
+++ b/capytale/contracts/src/workflow.ts
@@ -39,9 +39,11 @@ export type WorkflowV1 = {
     application: {
         /**
          * Le *MetaPlayer* appelle cette méthode pour indiquer le workflow à l'*Application*.
-         * Peut être appelé plusieurs fois.
+         * Cette méthode est appelée une première fois juste après un appel à `setMode` (si le contrat 
+         * `mode` a été souscrit) pour indiqué l'état initial, puis elle est rappelée à chaque fois que 
+         * l'état de la copie de l'élève/du participant est modifié.
          * 
-         * @param mode le mode à appliquer. 
+         * @param workflow: la nouvelle valeur du workflow à appliquer. 
         */
         setWorkflow(wf: Workflow): void;
     };

--- a/capytale/contracts/src/workflow.ts
+++ b/capytale/contracts/src/workflow.ts
@@ -1,5 +1,15 @@
 /**
- * Ce module définit la transmission du workflow de l'assignment.
+ * Ce module définit la transmission de l'état actuel du workflow de la copie d'un 
+ * élève/participant.
+ * L'état workflow peut prendre l'une des valeurs suivante :
+ * 
+ *    - `"current"`  - L'élève n'a pas encore rendu la copie.
+ *    - `"finished"` - L'élève a rendu la copie : il ne peut plus la modifier (il peut encore
+ *                     la consulter ou pas, selon le réglage du "mode d'accès" de l'activité,
+ *                     dans les paramètres de l'activité).
+ *    - `"corrected"` - L'enseignant a marqué la copie comme corrigée/évaluée.
+ * 
+ * Souscription avec `workdlow:{v}`, où `{v}` est le numéro de version du contrat.
  */
 
 type Workflow = 'current' | 'finished' | 'corrected';

--- a/capytale/contracts/src/workflow.ts
+++ b/capytale/contracts/src/workflow.ts
@@ -34,6 +34,7 @@ export type WorkflowV1 = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
+     * Toutes les méthodes sont asynchrones.
      */
     application: {
         /**

--- a/capytale/contracts/src/workflow.ts
+++ b/capytale/contracts/src/workflow.ts
@@ -24,7 +24,6 @@ export type WorkflowV1 = {
 
     /**
      * L'interface qui expose l'*Application* au *MetaPlayer*.
-     * Les méthodes non implantées sont ignorées.
      */
     application: {
         /**


### PR DESCRIPTION
Voici des suggestions de docstrings.

* [x] - Modifié - ~~Il y a sans doute des choses erronées, car j'y suis parfois allé au feeling, pour déduire ce qu'il se passe ou non. En particulier:  `reload` et `getContent`.~~

*  [x] - Modifié -  ~~Pour `reload`, justement : je me suis rendu compte en rédigeant ma suggestion qu'il y a potentiellement des différences à discuter selon que l'Application est une SWA ou non. C'est en particulier le fait que vous parliez d'un "éventuel" état à passer à `reload`, qui m'a fait m'interroger à ce sujet : du côté de CodEx, si j'ai bien compris, ce n'est pas du tout éventuel mais indispensable puisqu'on change carrément de page.~~ 

* [x] - "validé" (qui ne dit mot consent ;) ) - J'ai parfois parlé de `loadContent`  dans des contrats qui n'ont rien à voir. Ce n'est peut-être pas désirable (ou bien à reformuler en précisant "si le contrat est implanté" ?).

* [x]  - Modifié - ~~`getContent` (x2) : J'ai ajouté une info sur une contrainte de non modification des contenus durant la sauvegarde, côté Application. Il me semble en effet me souvenir de qqc à ce sujet... (et aussi parce que sinon, je ne voyais pas le but de `contentSaved`, donc "je me suis dit que ..."). Mais c'est vraiment au feeling.~~ 

---

Remarque :

À propos de `contentSaved()`, est-ce que ce ne serait pas intéressant d'y ajouter un argument booléen, pour indiquer à l'Application si la sauvegrade est un succès ou pas ? Vous avez déjà certainement du feedback dans la page elle-même, mais peut-être que l'Application pourrait un jour vouloir faire qqc de l'info ?